### PR TITLE
fix tiktok download

### DIFF
--- a/youtube_dlc/extractor/tiktok.py
+++ b/youtube_dlc/extractor/tiktok.py
@@ -133,6 +133,8 @@ class TikTokIE(TikTokBaseIE):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
+        # If we only call once, we get a 403 when downlaoding the video.
+        webpage = self._download_webpage(url, video_id, note='Downloading video webpage')
         webpage = self._download_webpage(url, video_id, note='Downloading video webpage')
         json_string = self._search_regex(
             r'id=\"__NEXT_DATA__\"\s+type=\"application\/json\"\s*[^>]+>\s*(?P<json_string_ld>[^<]+)',


### PR DESCRIPTION
Currently, tiktok downloads fail with status 403.
This request fixes that by downloading the page twice before trying the video.
This seems like a bug on their end since i noticed the same problem in the webapp:
the request for the video file fails with 403 when opening a video in a fresh incognito session, but it works when i reload.
