### PR TITLE
Fixed problem with JS player URL

### DIFF
--- a/youtube_dlc/extractor/youtube.py
+++ b/youtube_dlc/extractor/youtube.py
@@ -2051,7 +2051,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
                 if cipher:
                     if 's' in url_data or self._downloader.params.get('youtube_include_dash_manifest', True):
-                        ASSETS_RE = r'"assets":.+?"js":\s*("[^"]+")'
+                        ASSETS_RE = r'(?:"assets":.+?"js":\s*("[^"]+"))|(?:"jsUrl":\s*("[^"]+"))'
                         jsplayer_url_json = self._search_regex(
                             ASSETS_RE,
                             embed_webpage if age_gate else video_webpage,


### PR DESCRIPTION
The JS player URL could not be found anymore, possibly because of a change on Youtubes side.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Today, many youtube videos could not be resolved anymore, because the JS player url changed its location:
```
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['--verbose', '--no-warnings', '--dump-json', '--id', '--', 'WXzFCS72QIA']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, pref UTF-8
[debug] youtube-dlc version 2020.10.25
[debug] Git HEAD: 6f8557ec4
[debug] Python version 3.8.5 (CPython) - Linux-5.4.67-1-MANJARO-x86_64-with-glibc2.2.5
[debug] exe versions: ffmpeg 4.3.1, ffprobe 4.3.1, rtmpdump 2.4
[debug] Proxy map: {}
ERROR: Unable to extract JS player URL; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dlc with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/peet/GitRepos/yt-dlc/youtube_dlc/YoutubeDL.py", line 830, in extract_info
    ie_result = ie.extract(url)
  File "/home/peet/GitRepos/yt-dlc/youtube_dlc/extractor/common.py", line 532, in extract
    ie_result = self._real_extract(url)
  File "/home/peet/GitRepos/yt-dlc/youtube_dlc/extractor/youtube.py", line 2065, in _real_extract
    jsplayer_url_json = self._search_regex(
  File "/home/peet/GitRepos/yt-dlc/youtube_dlc/extractor/common.py", line 1010, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
youtube_dlc.utils.RegexNotFoundError: Unable to extract JS player URL; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dlc with the --verbose flag and include its complete output.
```
For one video, it sometimes worked and sometimes did not work for me, which might be caused by a segmented rollout on youtube's backend of some sort.
The fix was quite straightforward, I expanded the regex to recognize the new "jsUrl" config value. Both the old and the new content can be parsed now.
New location:
```
yt.setConfig({
	'WEB_PLAYER_CONTEXT_CONFIGS': {
		"WEB_PLAYER_CONTEXT_CONFIG_ID_EMBEDDED_PLAYER": {
			"rootElementId": "movie_player",
			"jsUrl": "/s/player/9b65e980/player_ias.vflset/en_US/base.js",
			"cssUrl": "/s/player/9b65e980/www-player-webp.css",
			"contextId": "WEB_PLAYER_CONTEXT_CONFIG_ID_EMBEDDED_PLAYER",
```
Previously, it was found here:
```
yt.setConfig({
	"VIDEO_ID": "WXzFCS72QIA",
	"INNERTUBE_API_KEY": "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8",
	"XHR_APIARY_HOST": "youtubei.youtube.com",
	"XSRF_FIELD_NAME": "session_token",
	"INNERTUBE_CONTEXT_CLIENT_NAME": 56,
	"POST_MESSAGE_ORIGIN": "*",
	"GAPI_HINT_PARAMS": "m;\/_\/scs\/abc-static\/_\/js\/k=gapi.gapi.en.9Ky5Gf3gP0o.O\/d=1\/ct=zgms\/rs=AHpOoo9ntgUgaVmSKxb6oXsk111880adyg\/m=__features__",
	"GAPI_HOST": "https:\/\/apis.google.com",
	"DELEGATED_SESSION_ID": null,
	"PLAYER_CONFIG": {
                "args": <removed>
		"attrs": {"height": "100%", "width": "100%", "id": "video-player"},
		"assets": {
			"player_canary_state": "none",
			"js": "\/s\/player\/9b65e980\/player_ias.vflset\/en_US\/base.js",
			"css": "\/s\/player\/9b65e980\/www-player-webp.css"
		}
	},
```