### PR TITLE
[bandcamp] fix failing test. remove subclass hack

### DIFF
--- a/youtube_dlc/extractor/bandcamp.py
+++ b/youtube_dlc/extractor/bandcamp.py
@@ -236,15 +236,6 @@ class BandcampIE(BandcampBaseIE):
         }
 
 
-class BandcampAlbumTrackIE(BandcampIE):
-    IE_NAME = "Bandcamp:albumtrack"
-    """Hack class to force album downloads to have prefixed track numbers by default"""
-    def _real_extract(self, url):
-        data = super()._real_extract(url)
-        data['title'] = '{:02d} - {} - {}'.format(data['track_number'], data['artist'], data['track'])
-        return data
-
-
 class BandcampAlbumIE(BandcampBaseIE):
     IE_NAME = 'Bandcamp:album'
     _VALID_URL = r'https?://(?:(?P<subdomain>[^.]+)\.)?bandcamp\.com(?:/album/(?P<album_id>[^/?#&]+))?'
@@ -341,7 +332,7 @@ class BandcampAlbumIE(BandcampBaseIE):
         entries = [
             self.url_result(
                 compat_urlparse.urljoin(url, track['title_link']),
-                ie=BandcampAlbumTrackIE.ie_key(),
+                ie=BandcampIE.ie_key(),
                 video_title=track['title'])
             for track in tracks
             if track.get('duration')]

--- a/youtube_dlc/extractor/extractors.py
+++ b/youtube_dlc/extractor/extractors.py
@@ -84,7 +84,7 @@ from .awaan import (
 )
 from .azmedien import AZMedienIE
 from .baidu import BaiduVideoIE
-from .bandcamp import BandcampIE, BandcampAlbumTrackIE, BandcampAlbumIE, BandcampWeeklyIE
+from .bandcamp import BandcampIE, BandcampAlbumIE, BandcampWeeklyIE
 from .bbc import (
     BBCCoUkIE,
     BBCCoUkArticleIE,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

Sorry, I didn't realize I broke tests with that previous pull. This removes the hack I added that set Bandcamp album downloads to have numbered filenames by default.