### PR TITLE
[newgrounds] fix: video download

### DIFF
--- a/youtube_dlc/extractor/newgrounds.py
+++ b/youtube_dlc/extractor/newgrounds.py
@@ -4,6 +4,7 @@ import re
 
 from .common import InfoExtractor
 from ..utils import (
+    ExtractorError,
     extract_attributes,
     int_or_none,
     parse_duration,
@@ -20,22 +21,22 @@ class NewgroundsIE(InfoExtractor):
         'info_dict': {
             'id': '549479',
             'ext': 'mp3',
-            'title': 'B7 - BusMode',
+            'title': 'Burn7 - B7 - BusMode',
             'uploader': 'Burn7',
             'timestamp': 1378878540,
             'upload_date': '20130911',
             'duration': 143,
         },
     }, {
-        'url': 'https://www.newgrounds.com/portal/view/673111',
-        'md5': '3394735822aab2478c31b1004fe5e5bc',
+        'url': 'https://www.newgrounds.com/portal/view/1',
+        'md5': 'fbfb40e2dc765a7e830cb251d370d981',
         'info_dict': {
-            'id': '673111',
+            'id': '1',
             'ext': 'mp4',
-            'title': 'Dancin',
-            'uploader': 'Squirrelman82',
-            'timestamp': 1460256780,
-            'upload_date': '20160410',
+            'title': 'Brian-Beaton - Scrotum 1',
+            'uploader': 'Brian-Beaton',
+            'timestamp': 955064100,
+            'upload_date': '20000406',
         },
     }, {
         # source format unavailable, additional mp4 formats
@@ -43,7 +44,7 @@ class NewgroundsIE(InfoExtractor):
         'info_dict': {
             'id': '689400',
             'ext': 'mp4',
-            'title': 'ZTV News Episode 8',
+            'title': 'Bennettthesage - ZTV News Episode 8',
             'uploader': 'BennettTheSage',
             'timestamp': 1487965140,
             'upload_date': '20170224',
@@ -55,42 +56,73 @@ class NewgroundsIE(InfoExtractor):
 
     def _real_extract(self, url):
         media_id = self._match_id(url)
-
+        formats = []
+        uploader = None
         webpage = self._download_webpage(url, media_id)
 
         title = self._html_search_regex(
             r'<title>([^>]+)</title>', webpage, 'title')
 
-        media_url = self._parse_json(self._search_regex(
-            r'"url"\s*:\s*("[^"]+"),', webpage, ''), media_id)
+        media_url_string = self._search_regex(
+            r'"url"\s*:\s*("[^"]+"),', webpage, 'media url', default=None, fatal=False)
 
-        formats = [{
-            'url': media_url,
-            'format_id': 'source',
-            'quality': 1,
-        }]
+        if media_url_string:
+            media_url = self._parse_json(media_url_string, media_id)
+            formats = [{
+                'url': media_url,
+                'format_id': 'source',
+                'quality': 1,
+            }]
 
-        max_resolution = int_or_none(self._search_regex(
-            r'max_resolution["\']\s*:\s*(\d+)', webpage, 'max resolution',
-            default=None))
-        if max_resolution:
-            url_base = media_url.rpartition('.')[0]
-            for resolution in (360, 720, 1080):
-                if resolution > max_resolution:
-                    break
-                formats.append({
-                    'url': '%s.%dp.mp4' % (url_base, resolution),
-                    'format_id': '%dp' % resolution,
-                    'height': resolution,
-                })
+            max_resolution = int_or_none(self._search_regex(
+                r'max_resolution["\']\s*:\s*(\d+)', webpage, 'max resolution',
+                default=None))
+            if max_resolution:
+                url_base = media_url.rpartition('.')[0]
+                for resolution in (360, 720, 1080):
+                    if resolution > max_resolution:
+                        break
+                    formats.append({
+                        'url': '%s.%dp.mp4' % (url_base, resolution),
+                        'format_id': '%dp' % resolution,
+                        'height': resolution,
+                    })
+        else:
+            video_id = int_or_none(self._search_regex(
+                r'data-movie-id=\\"([0-9]+)\\"', webpage, ''))
+            if not video_id:
+                raise ExtractorError('Could not extract media data')
+
+            url_video_data = 'https://www.newgrounds.com/portal/video/%s' % video_id
+            headers = {
+                'Accept': 'application/json',
+                'Referer': url,
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+            json_video = self._download_json(url_video_data, video_id, headers=headers, fatal=False)
+            if not json_video:
+                raise ExtractorError('Could not fetch media data')
+
+            uploader = json_video.get('author')
+            title = json_video.get('title')
+            media_formats = json_video.get('sources', [])
+            for media_format in media_formats:
+                media_sources = media_formats[media_format]
+                for source in media_sources:
+                    formats.append({
+                        'format_id': media_format,
+                        'quality': int_or_none(media_format[:-1]),
+                        'url': source.get('src')
+                    })
 
         self._check_formats(formats, media_id)
         self._sort_formats(formats)
 
-        uploader = self._html_search_regex(
-            (r'(?s)<h4[^>]*>(.+?)</h4>.*?<em>\s*Author\s*</em>',
-             r'(?:Author|Writer)\s*<a[^>]+>([^<]+)'), webpage, 'uploader',
-            fatal=False)
+        if not uploader:
+            uploader = self._html_search_regex(
+                (r'(?s)<h4[^>]*>(.+?)</h4>.*?<em>\s*(?:Author|Artist)\s*</em>',
+                 r'(?:Author|Writer)\s*<a[^>]+>([^<]+)'), webpage, 'uploader',
+                fatal=False)
 
         timestamp = unified_timestamp(self._html_search_regex(
             (r'<dt>\s*Uploaded\s*</dt>\s*<dd>([^<]+</dd>\s*<dd>[^<]+)',
@@ -108,6 +140,9 @@ class NewgroundsIE(InfoExtractor):
 
         if '<dd>Song' in webpage:
             formats[0]['vcodec'] = 'none'
+
+        if uploader:
+            title = "%s - %s" % (uploader, title)
 
         return {
             'id': media_id,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

Fixes #27 
Video urls are no longer directly in the page, and another fetch and parse has to be done to get them.
Also replaced video test case that has been deleted.