### PR TITLE
[generic] hook up the doodstream extractor to look for embeds

### DIFF
--- a/youtube_dlc/extractor/doodstream.py
+++ b/youtube_dlc/extractor/doodstream.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import string
 import random
 import time
+import re
 
 from .common import InfoExtractor
 
@@ -31,6 +32,12 @@ class DoodStreamIE(InfoExtractor):
             'thumbnail': 'https://img.doodcdn.com/snaps/8edqd5nppkac3x8u.jpg',
         }
     }]
+
+    @staticmethod
+    def _extract_urls(webpage):
+        return re.findall(
+            r'<iframe[^>]+?src=["\'](?P<url>(?:https?://)?dood\.(?:watch|to)/e/.+?)["\']',
+            webpage)
 
     def _real_extract(self, url):
         video_id = self._match_id(url)

--- a/youtube_dlc/extractor/generic.py
+++ b/youtube_dlc/extractor/generic.py
@@ -119,6 +119,7 @@ from .expressen import ExpressenIE
 from .zype import ZypeIE
 from .odnoklassniki import OdnoklassnikiIE
 from .kinja import KinjaEmbedIE
+from .doodstream import DoodStreamIE
 
 
 class GenericIE(InfoExtractor):
@@ -3190,6 +3191,11 @@ class GenericIE(InfoExtractor):
         if foxnews_urls:
             return self.playlist_from_matches(
                 foxnews_urls, video_id, video_title, ie=FoxNewsIE.ie_key())
+
+        doodstream_urls = DoodStreamIE._extract_urls(webpage)
+        if doodstream_urls:
+            return self.playlist_from_matches(
+                doodstream_urls, video_id, video_title, ie=DoodStreamIE.ie_key())
 
         sharevideos_urls = [sharevideos_mobj.group('url') for sharevideos_mobj in re.finditer(
             r'<iframe[^>]+?\bsrc\s*=\s*(["\'])(?P<url>(?:https?:)?//embed\.share-videos\.se/auto/embed/\d+\?.*?\buid=\d+.*?)\1',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Enable the generic extractor to utilise the doodstream extractor for embed url extraction.
