### PR TITLE
[vlive] fix extractor for revamped website

### DIFF
--- a/youtube_dlc/extractor/vlive.py
+++ b/youtube_dlc/extractor/vlive.py
@@ -119,13 +119,14 @@ class VLiveIE(NaverBaseIE):
             PARAMS_RE, webpage, PARAMS_FIELD, default='', flags=re.DOTALL)
         params = self._parse_json(params, working_id, fatal=False)
 
-        video_params = try_get(params, lambda x: x["postDetail"]["post"]["officialVideo"])
+        video_params = try_get(params, lambda x: x["postDetail"]["post"]["officialVideo"], dict)
 
         if video_params is None:
-            error_data = try_get(params, lambda x: x["postDetail"]["error"]["data"])
+            error_data = try_get(params, lambda x: x["postDetail"]["error"]["data"], dict)
             product_type = try_get(error_data,
                                    [lambda x: x["officialVideo"]["productType"],
-                                    lambda x: x["board"]["boardType"]])
+                                    lambda x: x["board"]["boardType"]],
+                                   compat_str)
             if product_type in ('VLIVE_PLUS', 'VLIVE+'):
                 self.raise_login_required('This video is only available for VLIVE+ subscribers')
             elif 'post' in url:
@@ -173,7 +174,7 @@ class VLiveIE(NaverBaseIE):
         play_info = self._download_json(LIVE_INFO_ENDPOINT, video_id,
                                         headers={"referer": "https://www.vlive.tv"})
 
-        streams = try_get(play_info, lambda x: x["result"]["streamList"]) or []
+        streams = try_get(play_info, lambda x: x["result"]["streamList"], list) or []
 
         formats = []
         for stream in streams:

--- a/youtube_dlc/extractor/vlive.py
+++ b/youtube_dlc/extractor/vlive.py
@@ -127,18 +127,12 @@ class VLiveIE(NaverBaseIE):
                 raise ExtractorError('Failed to extract video parameters.')
 
         video_id = working_id if 'video' in url else str(video_params["videoSeq"])
-        long_video_id = video_params["vodId"]
+
         video_type = video_params["type"]
-
-        VOD_KEY_ENDPOINT = 'https://www.vlive.tv/globalv-web/vam-web/video/v1.0/vod/%s/inkey' % video_id
-        key_json = self._download_json(VOD_KEY_ENDPOINT, video_id,
-                                       headers={"referer": "https://www.vlive.tv"})
-        key = key_json["inkey"]
-
         if video_type in ('VOD'):
             encoding_status = video_params["encodingStatus"]
             if encoding_status == 'COMPLETE':
-                return self._replay(video_id, webpage, long_video_id, key, params)
+                return self._replay(video_id, webpage, params, video_params)
             else:
                 raise ExtractorError('VOD encoding not yet complete. Please try again later.',
                                      expected=True)
@@ -193,7 +187,13 @@ class VLiveIE(NaverBaseIE):
         })
         return info
 
-    def _replay(self, video_id, webpage, long_video_id, key, params):
+    def _replay(self, video_id, webpage, params, video_params):
+        VOD_KEY_ENDPOINT = 'https://www.vlive.tv/globalv-web/vam-web/video/v1.0/vod/%s/inkey' % video_id
+        key_json = self._download_json(VOD_KEY_ENDPOINT, video_id,
+                                       headers={"referer": "https://www.vlive.tv"})
+        key = key_json["inkey"]
+        long_video_id = video_params["vodId"]
+
         if '' in (long_video_id, key):
             init_page = self._download_init_page(video_id)
             video_info = self._parse_json(self._search_regex(

--- a/youtube_dlc/extractor/vlive.py
+++ b/youtube_dlc/extractor/vlive.py
@@ -202,16 +202,6 @@ class VLiveIE(NaverBaseIE):
             self._get_common_fields(webpage, params),
             self._extract_video_info(video_id, long_video_id, key))
 
-    def _download_init_page(self, video_id):
-        return self._download_webpage(
-            'https://www.vlive.tv/video/init/view',
-            video_id, note='Downloading live webpage',
-            data=urlencode_postdata({'videoSeq': video_id}),
-            headers={
-                'Referer': 'https://www.vlive.tv/video/%s' % video_id,
-                'Content-Type': 'application/x-www-form-urlencoded'
-            })
-
 
 class VLiveChannelIE(InfoExtractor):
     IE_NAME = 'vlive:channel'

--- a/youtube_dlc/extractor/vlive.py
+++ b/youtube_dlc/extractor/vlive.py
@@ -144,8 +144,10 @@ class VLiveIE(NaverBaseIE):
                                      expected=True)
         elif video_type in ('LIVE'):
             video_status = video_params["status"]
-            if video_status == 'RESERVED':
+            if video_status in ('RESERVED'):
                 raise ExtractorError('Coming soon!', expected=True)
+            elif video_status in ('ENDED', 'END'):
+                raise ExtractorError('Uploading for replay. Please wait...', expected=True)
             else:
                 return self._live(video_id, webpage, params)
         else:

--- a/youtube_dlc/extractor/vlive.py
+++ b/youtube_dlc/extractor/vlive.py
@@ -220,15 +220,22 @@ class VLiveIE(NaverBaseIE):
 
 class VLiveChannelIE(InfoExtractor):
     IE_NAME = 'vlive:channel'
-    _VALID_URL = r'https?://channels\.vlive\.tv/(?P<id>[0-9A-Z]+)'
-    _TEST = {
-        'url': 'http://channels.vlive.tv/FCD4B',
+    _VALID_URL = r'https?://(?:(?:www|m)\.)?(?:channels\.vlive\.tv/|vlive\.tv/channels?/)(?P<id>[0-9A-Z]+)'
+    _TESTS = [{
+        'url': 'https://channels.vlive.tv/FCD4B',
         'info_dict': {
             'id': 'FCD4B',
             'title': 'MAMAMOO',
         },
         'playlist_mincount': 110
-    }
+    }, {
+        'url': 'https://www.vlive.tv/channel/FCD4B',
+        'info_dict': {
+            'id': 'FCD4B',
+            'title': 'MAMAMOO',
+        },
+        'playlist_mincount': 110
+    }]
     _APP_ID = '8c6cc7b45d2568fb668be6e05b6e5a3b'
 
     def _real_extract(self, url):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes vlive extractor for their revamped website. This should address #60 to some degree but is tested only with VODs and not with other video types such as live video. Thanks to @robindz in https://github.com/blackjack4494/yt-dlc/issues/60#issuecomment-719923648 for investigation into the fix.

The basic extractor now supports both video urls (eg `https://www.vlive.tv/video/1326`) and video post urls that point to the same video (eg `https://vlive.tv/post/1-18244258` which points to the same example video `1326`).

Adds support for new channel url format. The old format followed the example `https://channels.vlive.tv/FCD4B` while the new format follows the example `https://www.vlive.tv/channel/FCD4B`. The old format redirects to the new format. Additionally `https://www.vlive.tv/channel**s**/FCD4B` will also redirect to `https://www.vlive.tv/channel/FCD4B`. Also includes some regex improvements here, allowing `www` and `m` subdomains in channel urls.

Playlists seem to have been removed from my cursory investigation and I did not touch the playlist extractor code for now.

Edit 1: The live video extractor should now be fixed using the `https://www.vlive.tv/globalv-web/vam-web/old/v3/live/<videoSeq>/playInfo` endpoint. Thanks to @robindz and @SeonjaeHyeon for finding this endpoint.

Edit 2: Things missing so far: 
* extraction of playlists, which are still present in some form but may no longer be detectable from the url alone

Edit 3: Fixed detection of vlive+ paywalled videos. Login for vlive+ videos is likely missing.

Edit 4: Login is working, but downloading premium content is still broken. There may be a different endpoint or different headers that need to be passed to the current vod key endpoint `https://www.vlive.tv/globalv-web/vam-web/video/v1.0/vod/%s/inkey`. Playlists are also still not working. Work on these items could be continued in a new pull request.

