### PR TITLE
Fix issue triggered by tubeup

### DIFF
--- a/youtube_dlc/downloader/common.py
+++ b/youtube_dlc/downloader/common.py
@@ -364,8 +364,10 @@ class FileDownloader(object):
                         else '%.2f' % sleep_interval))
                 time.sleep(sleep_interval)
         else:
-            if self.params.get('sleep_interval_subtitles') > 0:
+            sleep_interval_sub = 0
+            if type(self.params.get('sleep_interval_subtitles')) is int:
                 sleep_interval_sub = self.params.get('sleep_interval_subtitles')
+            if sleep_interval_sub > 0:
                 self.to_screen(
                     '[download] Sleeping %s seconds...' % (
                         sleep_interval_sub))

--- a/youtube_dlc/downloader/youtube_live_chat.py
+++ b/youtube_dlc/downloader/youtube_live_chat.py
@@ -82,7 +82,10 @@ class YoutubeLiveChatReplayFD(FragmentFD):
                         offset = int(replay_chat_item_action['videoOffsetTimeMsec'])
                     processed_fragment.extend(
                         json.dumps(action, ensure_ascii=False).encode('utf-8') + b'\n')
-                continuation_id = live_chat_continuation['continuations'][0]['liveChatReplayContinuationData']['continuation']
+                try:
+                    continuation_id = live_chat_continuation['continuations'][0]['liveChatReplayContinuationData']['continuation']
+                except KeyError:
+                    continuation_id = None
 
             self._append_fragment(ctx, processed_fragment)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
This Pull Request fix some corner case that are triggered when yt-dlc is used through bibanon/tubeup:
* TypeError in downloader/common.py due to the 'sleep_interval_subtitles' params missing
* KeyError in downloader/youtube_live_chat.py when 'liveChatReplayContinuationData' doesn't have the 'continuation' key
