### PR TITLE
 Pre-check some video IDs in the archive before downloading

### DIFF
--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -2204,15 +2204,28 @@ class YoutubeDL(object):
         self.archive.add(vid_id)
 
     def url_archive_precheck(self, url):
-        # Check YouTube single video downloads in archive before any web page access
-        if re.match("^https://[a-zA-Z.]*youtube.com/", url):
-            temp_id = url.split("?v=")
+        # Check single video downloads in archive (if possible) before any web page access
+        ie_key = None
+        if re.match("^https://[0-9a-zA-Z.]*bitchute.com/video/", url):
+            temp_id = url.split("/video/")
             if len(temp_id) == 2:
+                ie_key = "bitchute"
                 temp_id = temp_id[1].split("&")[0]
-                temp_info_dict = {'id': temp_id, 'ie_key': "youtube"}
-                if self.in_download_archive(temp_info_dict):
-                    reason = "[download] [youtube] ID %s has already been recorded in archive" % temp_id
-                    return reason
+                temp_id = temp_id.split("/")[0]
+                temp_id = temp_id.split("?")[0]
+        elif re.match("^https://[0-9a-zA-Z.]*youtube.com/", url):
+            temp_id = url.split("?v=")
+            if len(temp_id) == 1:
+                temp_id = url.split("&v=")
+            if len(temp_id) == 2:
+                ie_key = "youtube"
+                temp_id = temp_id[1].split("&")[0]
+        # ie_key should only be set if an archive check should be done
+        if ie_key is not None:
+            temp_info_dict = {'id': temp_id, 'ie_key': ie_key}
+            if self.in_download_archive(temp_info_dict):
+                reason = "[download] [%s] ID %s has already been recorded in archive" % (ie_key, temp_id)
+                return reason
         return None
 
     @staticmethod


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
    This tries to stop single video downloads that are in the archive
    file from triggering any actual HTTP requests. This became an
    issue during the playlist download capability being broken by the
    disable_polymer option; as a workaround, I put together download
    batch files using a regex-manipulated copy of the playlist page
    DOM, so each batch file would run a download for each single video
    in a playlist rather than having the program fetch the playlist.

    The major problem is that even if a video ID is in the archive,
    the video info page must still be downloaded before it is ever
    checked within the archive for rejection. By checking the video ID
    before anything is downloaded, the rejection happens much faster
    and no unnecessary HTTP requests are sent out.

    This should be extended in the future for other services that do
    not require a page download to retrieve the video ID.

    This uses a regex match to check the site-specific URL and should
    basically be a no-op for all other sites.