### PR TITLE
make_win.bat: don't use UPX to pack vcruntime140.dll

### DIFF
--- a/make_win.bat
+++ b/make_win.bat
@@ -1,1 +1,1 @@
-py -m PyInstaller youtube_dlc\__main__.py --onefile --name youtube-dlc --version-file win\ver.txt --icon win\icon\cloud.ico
+py -m PyInstaller youtube_dlc\__main__.py --onefile --name youtube-dlc --version-file win\ver.txt --icon win\icon\cloud.ico --upx-exclude=vcruntime140.dll


### PR DESCRIPTION
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

If UPX is in the PATH, a corrupt Windows executable is produced. This prevents the offending DLL from being packed with UPX.