### PR TITLE
Option to force writing to archive without actually downloading the video

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ I will add some memorable short links to the binaries so you can download them e
                                      playlist information in a single line.
     --print-json                     Be quiet and print the video information as
                                      JSON (video is still being downloaded).
+    --force-write-archive            Force download archive entries to be written 
+                                     as far as no errors occur, even if -s or 
+                                     another simulation switch is used.
+                                     (Same as --force-download-archive)
     --newline                        Output progress bar as new lines
     --no-progress                    Do not print progress bar
     --console-title                  Display progress in console titlebar

--- a/README.md
+++ b/README.md
@@ -339,10 +339,11 @@ I will add some memorable short links to the binaries so you can download them e
                                      playlist information in a single line.
     --print-json                     Be quiet and print the video information as
                                      JSON (video is still being downloaded).
-    --force-write-archive            Force download archive entries to be written 
-                                     as far as no errors occur, even if -s or 
+    --force-write-download-archive   Force download archive entries to be written
+                                     as far as no errors occur, even if -s or
                                      another simulation switch is used.
-                                     (Same as --force-download-archive)
+                                     (Synonyms: --force-write-archive,
+                                     --force-download-archive)
     --newline                        Output progress bar as new lines
     --no-progress                    Do not print progress bar
     --console-title                  Display progress in console titlebar

--- a/test/parameters.json
+++ b/test/parameters.json
@@ -7,6 +7,7 @@
     "forcethumbnail": false, 
     "forcetitle": false, 
     "forceurl": false, 
+    "force_write_download_archive": false,
     "format": "best",
     "ignoreerrors": false, 
     "listformats": null, 

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -161,6 +161,8 @@ class YoutubeDL(object):
     forcejson:         Force printing info_dict as JSON.
     dump_single_json:  Force printing the info_dict of the whole playlist
                        (or video) as a single JSON line.
+    force_write_download_archive: Force writing download archive regardless of
+                       'skip_download' or 'simulate'.
     simulate:          Do not download the video files.
     format:            Video format code. See options.py for more information.
     outtmpl:           Template for output names.
@@ -1805,8 +1807,11 @@ class YoutubeDL(object):
         # Forced printings
         self.__forced_printings(info_dict, filename, incomplete=False)
 
-        # Do nothing else if in simulate mode
         if self.params.get('simulate', False):
+            if self.params.get('force_write_download_archive', False):
+                self.record_download_archive(info_dict)
+
+            # Do nothing else if in simulate mode
             return
 
         if filename is None:
@@ -2086,7 +2091,10 @@ class YoutubeDL(object):
                 except (PostProcessingError) as err:
                     self.report_error('postprocessing: %s' % str(err))
                     return
-                self.record_download_archive(info_dict)
+                must_record_download_archive = True
+
+        if must_record_download_archive or self.params.get('force_write_download_archive', False):
+            self.record_download_archive(info_dict)
 
     def download(self, url_list):
         """Download a given list of URLs."""

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -1948,6 +1948,8 @@ class YoutubeDL(object):
 
         self._write_thumbnails(info_dict, filename)
 
+        # Download
+        must_record_download_archive = False
         if not self.params.get('skip_download', False):
             try:
                 if info_dict.get('requested_formats') is not None:

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -344,6 +344,7 @@ def _real_main(argv=None):
         'forceformat': opts.getformat,
         'forcejson': opts.dumpjson or opts.print_json,
         'dump_single_json': opts.dump_single_json,
+        'force_write_download_archive': opts.force_write_download_archive,
         'simulate': opts.simulate or any_getting,
         'skip_download': opts.skip_download,
         'format': opts.format,

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -645,8 +645,13 @@ def parseOpts(overrideArguments=None):
     verbosity.add_option(
         '--print-json',
         action='store_true', dest='print_json', default=False,
-        help='Be quiet and print the video information as JSON (video is still being downloaded).',
-    )
+        help='Be quiet and print the video information as JSON (video is still being downloaded).')
+    verbosity.add_option(
+        '--force-write-download-archive', '--force-write-archive', '--force-download-archive',
+        action='store_true', dest='force_write_download_archive', default=False,
+        help=(
+            'Force download archive entries to be written as far as no errors occur,'
+            'even if -s or another simulation switch is used.'))
     verbosity.add_option(
         '--newline',
         action='store_true', dest='progress_with_newline', default=False,


### PR DESCRIPTION

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Adds a new option `--force-write-archive` which will force download archive entries to be written  as far as no errors occur, even if -s or another simulation switch is used.

The original author is @h-h-h-h. This was a pull request that existed before the takedown. I have the author's permission to make this PR. You can confirm it with him if needed