### PR TITLE
Option to present -F output in a more tabular form

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ I will add some memorable short links to the binaries so you can download them e
                                      one is requested
     -F, --list-formats               List all available formats of requested
                                      videos
+    --list-formats-as-table          Present the output of -F in a more tabular form
     --youtube-skip-dash-manifest     Do not download the DASH manifests and
                                      related data on YouTube videos
     --youtube-skip-hls-manifest      Do not download the HLS manifests and

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -2325,7 +2325,7 @@ class YoutubeDL(object):
                 for f in formats
                 if f.get('preference') is None or f['preference'] >= -1000]
             header_line = ['ID', 'EXT', 'RESOLUTION', 'FPS', '|', ' FILESIZE', '  TBR', 'PROTO',
-                           '|', 'VIDEO CODEC', '  VBR', 'AUDIO CODEC', ' ABR', ' ASR', 'NOTE']
+                           '|', 'VCODEC', '  VBR', 'ACODEC', ' ABR', ' ASR', 'NOTE']
         else:
             table = [
                 [
@@ -2340,8 +2340,12 @@ class YoutubeDL(object):
         if len(formats) > 1:
             table[-1][-1] += (' ' if table[-1][-1] else '') + '(best)'
         self.to_screen(
-            '[info] Available formats for %s:\n%s' %
-            (info_dict['id'], render_table(header_line, table, delim=new_format, extraGap=(0 if new_format else 1))))
+            '[info] Available formats for %s:\n%s' % (info_dict['id'], render_table(
+                header_line,
+                table, 
+                delim=new_format,
+                extraGap=(0 if new_format else 1),
+                hideEmpty=new_format)))
 
     def list_thumbnails(self, info_dict):
         thumbnails = info_dict.get('thumbnails')

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -2341,7 +2341,7 @@ class YoutubeDL(object):
             table[-1][-1] += (' ' if table[-1][-1] else '') + '(best)'
         self.to_screen(
             '[info] Available formats for %s:\n%s' %
-            (info_dict['id'], render_table(header_line, table, new_format)))
+            (info_dict['id'], render_table(header_line, table, delim=new_format, extraGap=(0 if new_format else 1))))
 
     def list_thumbnails(self, info_dict):
         thumbnails = info_dict.get('thumbnails')

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -2342,7 +2342,7 @@ class YoutubeDL(object):
         self.to_screen(
             '[info] Available formats for %s:\n%s' % (info_dict['id'], render_table(
                 header_line,
-                table, 
+                table,
                 delim=new_format,
                 extraGap=(0 if new_format else 1),
                 hideEmpty=new_format)))

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -2289,16 +2289,16 @@ class YoutubeDL(object):
                 res += ', '
             res += '~' + format_bytes(fdict['filesize_approx'])
         return res
- 
+
     def _format_note_table(self, f):
         def join_fields(*vargs):
             return ', '.join((val for val in vargs if val != ''))
 
         return join_fields(
             'UNSUPPORTED' if f.get('ext') in ('f4f', 'f4m') else '',
-            format_field(f, 'language', '[%s]'), 
-            format_field(f, 'format_note'), 
-            format_field(f, 'container', ignore=(None, f.get('ext'))), 
+            format_field(f, 'language', '[%s]'),
+            format_field(f, 'format_note'),
+            format_field(f, 'container', ignore=(None, f.get('ext'))),
             format_field(f, 'asr', '%5dHz'))
 
     def list_formats(self, info_dict):
@@ -2307,10 +2307,10 @@ class YoutubeDL(object):
         if new_format:
             table = [
                 [
-                    format_field(f, 'format_id'), 
+                    format_field(f, 'format_id'),
                     format_field(f, 'ext'),
                     self.format_resolution(f),
-                    format_field(f, 'fps', '%d'), 
+                    format_field(f, 'fps', '%d'),
                     '|',
                     format_field(f, 'filesize', ' %s', func=format_bytes) + format_field(f, 'filesize_approx', '~%s', func=format_bytes),
                     format_field(f, 'tbr', '%4dk'),
@@ -2324,7 +2324,7 @@ class YoutubeDL(object):
                     self._format_note_table(f)]
                 for f in formats
                 if f.get('preference') is None or f['preference'] >= -1000]
-            header_line = ['ID', 'EXT', 'RESOLUTION', 'FPS', '|', ' FILESIZE', '  TBR', 'PROTO', 
+            header_line = ['ID', 'EXT', 'RESOLUTION', 'FPS', '|', ' FILESIZE', '  TBR', 'PROTO',
                            '|', 'VIDEO CODEC', '  VBR', 'AUDIO CODEC', ' ABR', ' ASR', 'NOTE']
         else:
             table = [

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -348,6 +348,7 @@ def _real_main(argv=None):
         'skip_download': opts.skip_download,
         'format': opts.format,
         'listformats': opts.listformats,
+        'listformats_table': opts.listformats_table,
         'outtmpl': outtmpl,
         'autonumber_size': opts.autonumber_size,
         'autonumber_start': opts.autonumber_start,

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -411,6 +411,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='listformats',
         help='List all available formats of requested videos')
     video_format.add_option(
+        '--list-formats-as-table',
+        action='store_true', dest='listformats_table', default=False,
+        help='Present the output of -F in a more tabular form')
+    video_format.add_option(
         '--youtube-include-dash-manifest',
         action='store_true', dest='youtube_include_dash_manifest', default=True,
         help=optparse.SUPPRESS_HELP)

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -416,7 +416,7 @@ def parseOpts(overrideArguments=None):
         help='Present the output of -F in a more tabular form')
     video_format.add_option(
         '--list-formats-old',
-        action='store_false', dest='listformats_table'
+        action='store_false', dest='listformats_table',
         help=optparse.SUPPRESS_HELP)
     video_format.add_option(
         '--youtube-include-dash-manifest',

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -415,6 +415,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='listformats_table', default=False,
         help='Present the output of -F in a more tabular form')
     video_format.add_option(
+        '--list-formats-old',
+        action='store_false', dest='listformats_table'
+        help=optparse.SUPPRESS_HELP)
+    video_format.add_option(
         '--youtube-include-dash-manifest',
         action='store_true', dest='youtube_include_dash_manifest', default=True,
         help=optparse.SUPPRESS_HELP)

--- a/youtube_dlc/utils.py
+++ b/youtube_dlc/utils.py
@@ -4316,6 +4316,7 @@ def render_table(header_row, data, delim=False, extraGap=0, hideEmpty=False):
 
     def get_max_lens(table):
         return [max(len(compat_str(v)) for v in col) for col in zip(*table)]
+
     def filter_using_list(row, filterArray):
         return [col for (take, col) in zip(filterArray, row) if take]
 
@@ -4323,7 +4324,7 @@ def render_table(header_row, data, delim=False, extraGap=0, hideEmpty=False):
         max_lens = get_max_lens(data)
         header_row = filter_using_list(header_row, max_lens)
         data = [filter_using_list(row, max_lens) for row in data]
-    
+
     table = [header_row] + data
     max_lens = get_max_lens(table)
     if delim:
@@ -5728,7 +5729,7 @@ def random_birthday(year_field, month_field, day_field):
     }
 
 
-def format_field(obj, field, template='%s', ignore=(None,''), default='', func=None):
+def format_field(obj, field, template='%s', ignore=(None, ''), default='', func=None):
     val = obj.get(field, default)
     if func and val not in ignore:
         val = func(val)

--- a/youtube_dlc/utils.py
+++ b/youtube_dlc/utils.py
@@ -4311,13 +4311,13 @@ def determine_protocol(info_dict):
     return compat_urllib_parse_urlparse(url).scheme
 
 
-def render_table(header_row, data, delim=False):
+def render_table(header_row, data, delim=False, extraGap=0):
     """ Render a list of rows, each as a list of values """
     table = [header_row] + data
     max_lens = [max(len(compat_str(v)) for v in col) for col in zip(*table)]
     if delim:
         table = [header_row] + [['-' * ml for ml in max_lens]] + data
-    format_str = ' '.join('%-' + compat_str(ml) + 's' for ml in max_lens[:-1]) + ' %s'
+    format_str = ' '.join('%-' + compat_str(ml + extraGap) + 's' for ml in max_lens[:-1]) + ' %s'
     return '\n'.join(format_str % tuple(row) for row in table)
 
 

--- a/youtube_dlc/utils.py
+++ b/youtube_dlc/utils.py
@@ -4311,11 +4311,13 @@ def determine_protocol(info_dict):
     return compat_urllib_parse_urlparse(url).scheme
 
 
-def render_table(header_row, data):
+def render_table(header_row, data, delim=False):
     """ Render a list of rows, each as a list of values """
     table = [header_row] + data
     max_lens = [max(len(compat_str(v)) for v in col) for col in zip(*table)]
-    format_str = ' '.join('%-' + compat_str(ml + 1) + 's' for ml in max_lens[:-1]) + '%s'
+    if delim:
+        table = [header_row] + [['-' * ml for ml in max_lens]] + data
+    format_str = ' '.join('%-' + compat_str(ml) + 's' for ml in max_lens[:-1]) + ' %s'
     return '\n'.join(format_str % tuple(row) for row in table)
 
 
@@ -5713,3 +5715,10 @@ def random_birthday(year_field, month_field, day_field):
         month_field: str(random_date.month),
         day_field: str(random_date.day),
     }
+
+
+def format_field(obj, field, template='%s', ignore=(None,''), default='', func=None):
+    val = obj.get(field, default)
+    if func and val not in ignore:
+        val = func(val)
+    return template % val if val not in ignore else default

--- a/youtube_dlc/utils.py
+++ b/youtube_dlc/utils.py
@@ -4311,10 +4311,21 @@ def determine_protocol(info_dict):
     return compat_urllib_parse_urlparse(url).scheme
 
 
-def render_table(header_row, data, delim=False, extraGap=0):
+def render_table(header_row, data, delim=False, extraGap=0, hideEmpty=False):
     """ Render a list of rows, each as a list of values """
+
+    def get_max_lens(table):
+        return [max(len(compat_str(v)) for v in col) for col in zip(*table)]
+    def filter_using_list(row, filterArray):
+        return [col for (take, col) in zip(filterArray, row) if take]
+
+    if hideEmpty:
+        max_lens = get_max_lens(data)
+        header_row = filter_using_list(header_row, max_lens)
+        data = [filter_using_list(row, max_lens) for row in data]
+    
     table = [header_row] + data
-    max_lens = [max(len(compat_str(v)) for v in col) for col in zip(*table)]
+    max_lens = get_max_lens(table)
     if delim:
         table = [header_row] + [['-' * ml for ml in max_lens]] + data
     format_str = ' '.join('%-' + compat_str(ml + extraGap) + 's' for ml in max_lens[:-1]) + ' %s'


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I never liked how the output of  `-F` is formatted. So I changed it for my own personal use. ~~But I am now making it a PR just in case anyone else is interested. I will keep this as a draft until someone actually show interest in this.~~

I have added a new option `--list-formats-as-table` (and `--list-formats-old`) that allows the user to use the new output format if they want it. Since it is added as an option, backward compatibility is not an issue.

Before:
```
[youtube] BaW_jenozKc: Downloading webpage
[info] Available formats for BaW_jenozKc:
format code  extension  resolution note
249          webm       audio only tiny   48k , opus @ 50k (48000Hz), 58.17KiB
250          webm       audio only tiny   63k , opus @ 70k (48000Hz), 76.07KiB
251          webm       audio only tiny  115k , opus @160k (48000Hz), 138.96KiB
140          m4a        audio only tiny  127k , m4a_dash container, mp4a.40.2@128k (44100Hz), 154.06KiB
242          webm       426x240    240p   28k , vp9, 30fps, video only, 33.27KiB
278          webm       256x144    144p   49k , webm container, vp9, 30fps, video only, 52.22KiB
243          webm       640x360    360p   67k , vp9, 30fps, video only, 75.55KiB
160          mp4        256x144    144p  115k , avc1.4d400c, 15fps, video only, 135.08KiB
244          webm       854x480    480p  158k , vp9, 30fps, video only, 165.49KiB
133          mp4        426x240    240p  246k , avc1.4d4015, 30fps, video only, 294.27KiB
134          mp4        640x360    360p  294k , avc1.4d401e, 30fps, video only, 349.59KiB
247          webm       1280x720   720p  448k , vp9, 30fps, video only, 504.68KiB
135          mp4        854x480    480p  727k , avc1.4d401f, 30fps, video only, 849.41KiB
248          webm       1920x1080  1080p  879k , vp9, 30fps, video only, 965.31KiB
136          mp4        1280x720   720p 1425k , avc1.4d401f, 30fps, video only, 1.60MiB
137          mp4        1920x1080  1080p 1835k , avc1.640028, 30fps, video only, 2.11MiB
18           mp4        640x360    360p  295k , avc1.42001E, 30fps, mp4a.40.2@ 96k (44100Hz), 354.29KiB
22           mp4        1280x720   720p 1493k , avc1.64001F, 30fps, mp4a.40.2@192k (44100Hz) (best)
```

After:
```
[youtube] BaW_jenozKc: Downloading webpage
[info] Available formats for BaW_jenozKc:
ID  EXT  RESOLUTION FPS |  FILESIZE    TBR PROTO | VIDEO CODEC   VBR AUDIO CODEC  ABR  ASR    NOTE
--- ---- ---------- --- - ---------- ----- ----- - ----------- ----- ----------- ---- ------- -----------------------
249 webm audio only     |  58.17KiB    48k https |                   opus         50k 48000Hz tiny, 48000Hz
250 webm audio only     |  76.07KiB    63k https |                   opus         70k 48000Hz tiny, 48000Hz
251 webm audio only     |  138.96KiB  115k https |                   opus        160k 48000Hz tiny, 48000Hz
140 m4a  audio only     |  154.06KiB  127k https |                   mp4a.40.2   128k 44100Hz tiny, m4a_dash, 44100Hz
242 webm 426x240    30  |  33.27KiB    28k https | vp9                                        240p
278 webm 256x144    30  |  52.22KiB    49k https | vp9                                        144p
243 webm 640x360    30  |  75.55KiB    67k https | vp9                                        360p
160 mp4  256x144    15  |  135.08KiB  115k https | avc1.4d400c                                144p
244 webm 854x480    30  |  165.49KiB  158k https | vp9                                        480p
133 mp4  426x240    30  |  294.27KiB  246k https | avc1.4d4015                                240p
134 mp4  640x360    30  |  349.59KiB  294k https | avc1.4d401e                                360p
247 webm 1280x720   30  |  504.68KiB  448k https | vp9                                        720p
135 mp4  854x480    30  |  849.41KiB  727k https | avc1.4d401f                                480p
248 webm 1920x1080  30  |  965.31KiB  879k https | vp9                                        1080p
136 mp4  1280x720   30  |  1.60MiB   1425k https | avc1.4d401f                                720p
137 mp4  1920x1080  30  |  2.11MiB   1835k https | avc1.640028                                1080p
18  mp4  640x360    30  |  354.29KiB  295k https | avc1.42001E       mp4a.40.2    96k 44100Hz 360p, 44100Hz
22  mp4  1280x720   30  |            1493k https | avc1.64001F       mp4a.40.2   192k 44100Hz 720p, 44100Hz (best)
```