### PR TITLE
[ffmpeg] Fix for os.rename error when embedding thumbnail to video in a different drive on windows

### DIFF
--- a/youtube_dlc/postprocessor/embedthumbnail.py
+++ b/youtube_dlc/postprocessor/embedthumbnail.py
@@ -89,9 +89,10 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             os.rename(encodeFilename(temp_filename), encodeFilename(filename))
 
         elif info['ext'] == 'mkv':
-            os.rename(encodeFilename(thumbnail_filename), encodeFilename('cover.jpg'))
             old_thumbnail_filename = thumbnail_filename
-            thumbnail_filename = 'cover.jpg'
+            thumbnail_filename = os.path.join(os.path.dirname(old_thumbnail_filename), 'cover.jpg')
+            os.remove(encodeFilename(thumbnail_filename))
+            os.rename(encodeFilename(old_thumbnail_filename), encodeFilename(thumbnail_filename))
 
             options = [
                 '-c', 'copy', '-attach', thumbnail_filename, '-metadata:s:t', 'mimetype=image/jpeg']

--- a/youtube_dlc/postprocessor/embedthumbnail.py
+++ b/youtube_dlc/postprocessor/embedthumbnail.py
@@ -91,7 +91,8 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         elif info['ext'] == 'mkv':
             old_thumbnail_filename = thumbnail_filename
             thumbnail_filename = os.path.join(os.path.dirname(old_thumbnail_filename), 'cover.jpg')
-            os.remove(encodeFilename(thumbnail_filename))
+            if os.path.exists(thumbnail_filename):
+                os.remove(encodeFilename(thumbnail_filename))
             os.rename(encodeFilename(old_thumbnail_filename), encodeFilename(thumbnail_filename))
 
             options = [


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

See title