### PR TITLE
[youtube] fix: ytsearch not returning results sometimes due to promoted content

### DIFF
--- a/youtube_dlc/extractor/youtube.py
+++ b/youtube_dlc/extractor/youtube.py
@@ -3336,10 +3336,33 @@ class YoutubeSearchIE(SearchInfoExtractor, YoutubePlaylistBaseInfoExtractor):
                 list)
             if not slr_contents:
                 break
-            isr_contents = try_get(
-                slr_contents,
-                lambda x: x[0]['itemSectionRenderer']['contents'],
-                list)
+
+            isr_contents = []
+            continuation_token = None
+            # Youtube sometimes adds promoted content to searches,
+            # changing the index location of videos and token.
+            # So we search through all entries till we find them.
+            for index, isr in enumerate(slr_contents):
+                if len(isr_contents) == 0:
+                    isr_contents = try_get(
+                        slr_contents,
+                        (lambda x: x[index]['itemSectionRenderer']['contents']),
+                        list)
+                    for content in isr_contents:
+                        if content.get('videoRenderer') is not None:
+                            break
+                    else:
+                        isr_contents = []
+
+                if continuation_token is None:
+                    continuation_token = try_get(
+                        slr_contents,
+                        lambda x: x[index]['continuationItemRenderer']['continuationEndpoint']['continuationCommand'][
+                            'token'],
+                        compat_str)
+                if continuation_token is not None and isr_contents != []:
+                    break
+
             if not isr_contents:
                 break
             for content in isr_contents:
@@ -3373,13 +3396,9 @@ class YoutubeSearchIE(SearchInfoExtractor, YoutubePlaylistBaseInfoExtractor):
                 }
                 if total == n:
                     return
-            token = try_get(
-                slr_contents,
-                lambda x: x[1]['continuationItemRenderer']['continuationEndpoint']['continuationCommand']['token'],
-                compat_str)
-            if not token:
+            if not continuation_token:
                 break
-            data['continuation'] = token
+            data['continuation'] = continuation_token
 
     def _get_n_results(self, query, n):
         """Get a specified number of results for a query"""

--- a/youtube_dlc/extractor/youtube.py
+++ b/youtube_dlc/extractor/youtube.py
@@ -3343,7 +3343,7 @@ class YoutubeSearchIE(SearchInfoExtractor, YoutubePlaylistBaseInfoExtractor):
             # changing the index location of videos and token.
             # So we search through all entries till we find them.
             for index, isr in enumerate(slr_contents):
-                if len(isr_contents) == 0:
+                if not isr_contents:
                     isr_contents = try_get(
                         slr_contents,
                         (lambda x: x[index]['itemSectionRenderer']['contents']),
@@ -3360,7 +3360,7 @@ class YoutubeSearchIE(SearchInfoExtractor, YoutubePlaylistBaseInfoExtractor):
                         lambda x: x[index]['continuationItemRenderer']['continuationEndpoint']['continuationCommand'][
                             'token'],
                         compat_str)
-                if continuation_token is not None and isr_contents != []:
+                if continuation_token is not None and isr_contents:
                     break
 
             if not isr_contents:


### PR DESCRIPTION

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Fixes #201 
Sometimes YouTube adds "promoted" content among other unwanted stuff in the search results. This would change the index position of the actual video content we want (as well as any continuation token) in the data. The previous code had a hard-coded index position for this and would incorrectly pick up the promoted content and return 0 results.

This fix removes those hard-coded index positions to opt for iterating through the data till we find the actual video content and any continuation token.
