### PR TITLE
Sponskrub integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,17 @@ I will add some memorable short links to the binaries so you can download them e
     --convert-subs FORMAT            Convert the subtitles to other format
                                      (currently supported: srt|ass|vtt|lrc)
 
+## SponSkrub Options (SponsorBlock)
+    --sponskrub                      Use sponskrub to mark sponsored sections
+                                     with the data available in SponsorBlock API
+                                     (Youtube only)
+    --sponskrub-cut                  Cut out the sponsor sections instead of
+                                     simply marking them (Experimental)
+    --sponskrub-location             Location of the sponskrub binary;
+                                     either the path to the binary or its
+                                     containing directory
+    --sponskrub-args                 Give these arguments to sponskrub
+
 ## Extractor Options:
     --ignore-dynamic-mpd             Do not process dynamic DASH manifests
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,9 @@ I will add some memorable short links to the binaries so you can download them e
                                      with the data available in SponsorBlock API
                                      (Youtube only)
     --sponskrub-cut                  Cut out the sponsor sections instead of
-                                     simply marking them (Experimental)
+                                     simply marking them
+    --sponskrub-force                Run sponskrub even if the video was
+                                     already downloaded. Use with caution
     --sponskrub-location             Location of the sponskrub binary;
                                      either the path to the binary or its
                                      containing directory

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -2002,13 +2002,16 @@ class YoutubeDL(object):
                             if not ensure_dir_exists(fname):
                                 return
                             downloaded.append(fname)
-                            partial_success = dl(fname, new_info)
+                            partial_success, real_download = dl(fname, new_info)
                             success = success and partial_success
                         info_dict['__postprocessors'] = postprocessors
                         info_dict['__files_to_merge'] = downloaded
+                        # Even if there were no downloads, it is being merged only now
+                        info_dict['__real_download'] = True
                 else:
                     # Just a single file
-                    success = dl(filename, info_dict)
+                    success, real_download = dl(filename, info_dict)
+                    info_dict['__real_download'] = real_download
             except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                 self.report_error('unable to download video data: %s' % error_to_compat_str(err))
                 return

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -313,6 +313,7 @@ def _real_main(argv=None):
             'path': opts.sponskrub_path,
             'args': opts.sponskrub_args,
             'cut': opts.sponskrub_cut,
+            'force': opts.sponskrub_force,
             'ignoreerror': opts.sponskrub is None,
         })
     # Please keep ExecAfterDownload towards the bottom as it allows the user to modify the final file in any way.

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -305,6 +305,16 @@ def _real_main(argv=None):
     # contents
     if opts.xattrs:
         postprocessors.append({'key': 'XAttrMetadata'})
+    # This should be below all ffmpeg PP because it may cut parts out from the video
+    # If opts.sponskrub is None, sponskrub is used, but it silently fails if the executable can't be found
+    if opts.sponskrub is not False:
+        postprocessors.append({
+            'key': 'SponSkrub',
+            'path': opts.sponskrub_path,
+            'args': opts.sponskrub_args,
+            'cut': opts.sponskrub_cut,
+            'ignoreerror': opts.sponskrub is None,
+        })
     # Please keep ExecAfterDownload towards the bottom as it allows the user to modify the final file in any way.
     # So if the user is able to remove the file before your postprocessor runs it might cause a few problems.
     if opts.exec_cmd:

--- a/youtube_dlc/downloader/common.py
+++ b/youtube_dlc/downloader/common.py
@@ -351,7 +351,7 @@ class FileDownloader(object):
                     'status': 'finished',
                     'total_bytes': os.path.getsize(encodeFilename(filename)),
                 })
-                return True
+                return True, False
 
         if subtitle is False:
             min_sleep_interval = self.params.get('sleep_interval')
@@ -372,7 +372,7 @@ class FileDownloader(object):
                     '[download] Sleeping %s seconds...' % (
                         sleep_interval_sub))
                 time.sleep(sleep_interval_sub)
-        return self.real_download(filename, info_dict)
+        return self.real_download(filename, info_dict), True
 
     def real_download(self, filename, info_dict):
         """Real download process. Redefine in subclasses."""

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -881,7 +881,7 @@ def parseOpts(overrideArguments=None):
     extractor = optparse.OptionGroup(parser, 'SponSkrub Options (SponsorBlock)')
     extractor.add_option(
         '--sponskrub',
-        action='store_true', dest='sponskrub', default=False,  # should default be None instead?
+        action='store_true', dest='sponskrub', default=None,
         help='Use sponskrub to mark sponsored sections with the data available in SponsorBlock API (Youtube only)')
     extractor.add_option(
         '--no-sponskrub',

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -890,7 +890,11 @@ def parseOpts(overrideArguments=None):
     extractor.add_option(
         '--sponskrub-cut', default=False,
         action='store_true', dest='sponskrub_cut',
-        help='Cut out the sponsor sections instead of simply marking them (Experimental)')
+        help='Cut out the sponsor sections instead of simply marking them')
+    extractor.add_option(
+        '--sponskrub-force', default=False,
+        action='store_true', dest='sponskrub_force',
+        help='Run sponskrub even if the video was already downloaded')
     extractor.add_option(
         '--sponskrub-location', metavar='PATH',
         dest='sponskrub_path', default='',

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -878,6 +878,27 @@ def parseOpts(overrideArguments=None):
         metavar='FORMAT', dest='convertsubtitles', default=None,
         help='Convert the subtitles to other format (currently supported: srt|ass|vtt|lrc)')
 
+    extractor = optparse.OptionGroup(parser, 'SponSkrub Options (SponsorBlock)')
+    extractor.add_option(
+        '--sponskrub',
+        action='store_true', dest='sponskrub', default=False,  # should default be None instead?
+        help='Use sponskrub to mark sponsored sections with the data available in SponsorBlock API (Youtube only)')
+    extractor.add_option(
+        '--no-sponskrub',
+        action='store_false', dest='sponskrub',
+        help=optparse.SUPPRESS_HELP)
+    extractor.add_option(
+        '--sponskrub-cut', default=False,
+        action='store_true', dest='sponskrub_cut',
+        help='Cut out the sponsor sections instead of simply marking them (Experimental)')
+    extractor.add_option(
+        '--sponskrub-location', metavar='PATH',
+        dest='sponskrub_path', default='',
+        help='Location of the sponskrub binary; either the path to the binary or its containing directory.')
+    extractor.add_option(
+        '--sponskrub-args', dest='sponskrub_args',
+        help='Give these arguments to sponskrub')
+
     extractor = optparse.OptionGroup(parser, 'Extractor Options')
     extractor.add_option(
         '--allow-dynamic-mpd',

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -878,28 +878,38 @@ def parseOpts(overrideArguments=None):
         metavar='FORMAT', dest='convertsubtitles', default=None,
         help='Convert the subtitles to other format (currently supported: srt|ass|vtt|lrc)')
 
-    extractor = optparse.OptionGroup(parser, 'SponSkrub Options (SponsorBlock)')
-    extractor.add_option(
+    sponskrub = optparse.OptionGroup(parser, 'SponSkrub Options (SponsorBlock)')
+    sponskrub.add_option(
         '--sponskrub',
         action='store_true', dest='sponskrub', default=None,
-        help='Use sponskrub to mark sponsored sections with the data available in SponsorBlock API (Youtube only)')
-    extractor.add_option(
+        help=(
+            'Use sponskrub to mark sponsored sections with the data available in SponsorBlock API. '
+            'This is enabled by default if the sponskrub binary exists (Youtube only)'))
+    sponskrub.add_option(
         '--no-sponskrub',
         action='store_false', dest='sponskrub',
-        help=optparse.SUPPRESS_HELP)
-    extractor.add_option(
+        help='Do not use sponskrub')
+    sponskrub.add_option(
         '--sponskrub-cut', default=False,
         action='store_true', dest='sponskrub_cut',
         help='Cut out the sponsor sections instead of simply marking them')
-    extractor.add_option(
+    sponskrub.add_option(
+        '--no-sponskrub-cut',
+        action='store_false', dest='sponskrub_cut',
+        help='Simply mark the sponsor sections, not cut them out (default)')
+    sponskrub.add_option(
         '--sponskrub-force', default=False,
         action='store_true', dest='sponskrub_force',
         help='Run sponskrub even if the video was already downloaded')
-    extractor.add_option(
+    sponskrub.add_option(
+        '--no-sponskrub-force',
+        action='store_true', dest='sponskrub_force',
+        help='Do not cut out the sponsor sections if the video was already downloaded (default)')
+    sponskrub.add_option(
         '--sponskrub-location', metavar='PATH',
         dest='sponskrub_path', default='',
         help='Location of the sponskrub binary; either the path to the binary or its containing directory.')
-    extractor.add_option(
+    sponskrub.add_option(
         '--sponskrub-args', dest='sponskrub_args',
         help='Give these arguments to sponskrub')
 
@@ -927,6 +937,7 @@ def parseOpts(overrideArguments=None):
     parser.add_option_group(authentication)
     parser.add_option_group(adobe_pass)
     parser.add_option_group(postproc)
+    parser.add_option_group(sponskrub)
     parser.add_option_group(extractor)
 
     if overrideArguments is not None:

--- a/youtube_dlc/postprocessor/__init__.py
+++ b/youtube_dlc/postprocessor/__init__.py
@@ -17,6 +17,7 @@ from .ffmpeg import (
 from .xattrpp import XAttrMetadataPP
 from .execafterdownload import ExecAfterDownloadPP
 from .metadatafromtitle import MetadataFromTitlePP
+from .sponskrub import SponSkrubPP
 
 
 def get_postprocessor(key):
@@ -38,5 +39,6 @@ __all__ = [
     'FFmpegVideoConvertorPP',
     'FFmpegVideoRemuxerPP',
     'MetadataFromTitlePP',
+    'SponSkrubPP',
     'XAttrMetadataPP',
 ]

--- a/youtube_dlc/postprocessor/sponskrub.py
+++ b/youtube_dlc/postprocessor/sponskrub.py
@@ -53,9 +53,9 @@ class SponSkrubPP(PostProcessor):
 
         self._downloader.to_screen('[sponskrub] Trying to %s sponsor sections' % ('remove' if self.cutout else 'mark'))
         if self.cutout:
-            self._downloader.to_screen('WARNING: Cutting out sponsor segments will cause the subtitles to go out of sync.')
+            self._downloader.report_warning('Cutting out sponsor segments will cause the subtitles to go out of sync.')
             if not information.get('__real_download', False):
-                self._downloader.to_screen('WARNING: If sponskrub is run multiple times, unintended parts of the video could be cut out.')
+                self._downloader.report_warning('If sponskrub is run multiple times, unintended parts of the video could be cut out.')
 
         filename = information['filepath']
         temp_filename = filename + '.' + self._temp_ext + os.path.splitext(filename)[1]
@@ -69,7 +69,7 @@ class SponSkrubPP(PostProcessor):
         cmd = [encodeArgument(i) for i in cmd]
 
         if self._downloader.params.get('verbose', False):
-            self._downloader.to_screen('[debug] sponskrub command line: %s' % shell_quote(cmd))
+            self._downloader.to_stderr('[debug] sponskrub command line: %s' % shell_quote(cmd))
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
         stdout, stderr = p.communicate()
 

--- a/youtube_dlc/postprocessor/sponskrub.py
+++ b/youtube_dlc/postprocessor/sponskrub.py
@@ -1,0 +1,81 @@
+from __future__ import unicode_literals
+import os
+import subprocess
+
+from .common import PostProcessor
+from ..compat import compat_shlex_split
+from ..utils import (
+    check_executable,
+    encodeArgument,
+    shell_quote,
+    PostProcessingError,
+)
+
+
+class SponSkrubPP(PostProcessor):
+    _temp_ext = 'spons'
+    _def_args = []
+    _exe_name = 'sponskrub'
+
+    def __init__(self, downloader, path='', args=None, ignoreerror=False, cut=False):
+        PostProcessor.__init__(self, downloader)
+        self.cutout = cut
+        self.args = ['-chapter'] if not cut else []
+        self.args += self._def_args if args is None else compat_shlex_split(args)
+        self.path = self.get_exe(path)
+
+        if not ignoreerror and self.path is None:
+            if path:
+                raise PostProcessingError('sponskrub not found in "%s"' % path)
+            else:
+                raise PostProcessingError('sponskrub not found. Please install or provide the path using --sponskrub-path.')
+
+    def get_exe(self, path=''):
+        if not path or not check_executable(path, ['-h']):
+            path = os.path.join(path, self._exe_name)
+            if not check_executable(path, ['-h']):
+                return None
+        return path
+
+    def run(self, information):
+        if self.path is None:
+            return [], information
+
+        if information['extractor_key'].lower() != 'youtube':
+            self._downloader.to_screen('[sponskrub] Skipping SponSkrub since it is not a YouTube video')
+            return [], information
+
+        self._downloader.to_screen('[sponskrub] Trying to %s sponsor sections' % ('remove' if self.cutout else 'mark'))
+        if self.cutout:
+            self._downloader.to_screen(
+                'WARNING: The sponsor segments are cut out from the video based on timestamp. '
+                'This will cause the subtitles to go out of sync. '
+                'Also, if run multiple times, unintended parts of the video could be cut out.')
+
+        filename = information['filepath']
+        temp_filename = filename + '.' + self._temp_ext + os.path.splitext(filename)[1]
+        if os.path.exists(temp_filename):
+            os.remove(temp_filename)
+
+        cmd = [self.path]
+        if self.args:
+            cmd += self.args
+        cmd += ['--', information['id'], filename, temp_filename]
+        cmd = [encodeArgument(i) for i in cmd]
+
+        if self._downloader.params.get('verbose', False):
+            self._downloader.to_screen('[debug] SponSkrub command line: %s' % shell_quote(cmd))
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+
+        if p.returncode == 0:
+            os.remove(filename)
+            os.rename(temp_filename, filename)
+            self._downloader.to_screen('[sponskrub] Sponsor sections have been %s' % ('removed' if self.cutout else 'marked'))
+        elif p.returncode != 3:  # error code 3 means there was no info about the video
+            stderr = stderr.decode('utf-8', 'replace')
+            msg = stderr.strip().split('\n')[-1]
+            raise PostProcessingError(msg if msg else 'Sponskrub failed with error code %s!' % p.returncode)
+        else:
+            self._downloader.to_screen('[sponskrub] No segments in the SponsorBlock database')
+        return [], information


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Use [SponSkrub](https://github.com/faissaloo/SponSkrub) to cut out sponsor segments from youtube videos. Closes #209 

~~This is currently just a proof of concept. It needs more testing and refinement before being ready for use.~~

    --sponskrub                      Use sponskrub to mark sponsored sections
                                     with the data available in SponsorBlock API
                                     (Youtube only)
    --sponskrub-cut                  Cut out the sponsor sections instead of
                                     simply marking them
    --sponskrub-force                Run sponskrub even if the video was
                                     already downloaded. Use with caution
    --sponskrub-location             Location of the sponskrub binary;
                                     either the path to the binary or its
                                     containing directory
    --sponskrub-args                 Give these arguments to sponskrub

When using `--sponskrub-cut`, the postprocessor is run only if the video was downloaded/merged in the current run. This ensures that the the video does not get cut at sponsor timestamps multiple times. 

If the user (for whatever reason) wants to run the postprocessor on existing files, `--sponskrub-force` can be used.