### PR TITLE
[youtube] fix: better error message when calling extract_info on unavailable video

### DIFF
--- a/youtube_dlc/extractor/youtube.py
+++ b/youtube_dlc/extractor/youtube.py
@@ -1937,24 +1937,25 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             age_gate = False
             # Try looking directly into the video webpage
             ytplayer_config = self._get_ytplayer_config(video_id, video_webpage)
-            args = ytplayer_config.get("args")
-            if args is not None:
-                if args.get('url_encoded_fmt_stream_map') or args.get('hlsvp'):
-                    # Convert to the same format returned by compat_parse_qs
-                    video_info = dict((k, [v]) for k, v in args.items())
-                    add_dash_mpd(video_info)
-                # Rental video is not rented but preview is available (e.g.
-                # https://www.youtube.com/watch?v=yYr8q0y5Jfg,
-                # https://github.com/ytdl-org/youtube-dl/issues/10532)
-                if not video_info and args.get('ypc_vid'):
-                    return self.url_result(
-                        args['ypc_vid'], YoutubeIE.ie_key(), video_id=args['ypc_vid'])
-                if args.get('livestream') == '1' or args.get('live_playback') == 1:
-                    is_live = True
-                if not player_response:
-                    player_response = extract_player_response(args.get('player_response'), video_id)
-            elif not player_response:
-                player_response = ytplayer_config
+            if ytplayer_config:
+                args = ytplayer_config.get("args")
+                if args is not None:
+                    if args.get('url_encoded_fmt_stream_map') or args.get('hlsvp'):
+                        # Convert to the same format returned by compat_parse_qs
+                        video_info = dict((k, [v]) for k, v in args.items())
+                        add_dash_mpd(video_info)
+                    # Rental video is not rented but preview is available (e.g.
+                    # https://www.youtube.com/watch?v=yYr8q0y5Jfg,
+                    # https://github.com/ytdl-org/youtube-dl/issues/10532)
+                    if not video_info and args.get('ypc_vid'):
+                        return self.url_result(
+                            args['ypc_vid'], YoutubeIE.ie_key(), video_id=args['ypc_vid'])
+                    if args.get('livestream') == '1' or args.get('live_playback') == 1:
+                        is_live = True
+                    if not player_response:
+                        player_response = extract_player_response(args.get('player_response'), video_id)
+                elif not player_response:
+                    player_response = ytplayer_config
             if not video_info or self._downloader.params.get('youtube_include_dash_manifest', True):
                 add_dash_mpd_pr(player_response)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Calling `extract_info` with an unavailable video failed with an exception, e.g.:

```
>>> a=youtube_dl.YoutubeDL()
>>> a.extract_info('https://www.youtube.com/watch?v=6iRV8liah8A')
[youtube] 6iRV8liah8A: Downloading webpage
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/dist-packages/youtube_dlc/YoutubeDL.py", line 830, in extract_info
    ie_result = ie.extract(url)
  File "/usr/local/lib/python3.8/dist-packages/youtube_dlc/extractor/common.py", line 532, in extract
    ie_result = self._real_extract(url)
  File "/usr/local/lib/python3.8/dist-packages/youtube_dlc/extractor/youtube.py", line 1940, in _real_extract
    args = ytplayer_config.get("args")
AttributeError: 'NoneType' object has no attribute 'get'
```

This changes the behaviour to not use ytplayer_config if it is None, giving the more helpful error "Unable to extract video data".

Lines 1937-1958 are a direct copy of lines 1889-1910, but it involves a lot of variable setting so I couldn't see an easy way to extract it, so I left it as it was.