### PR TITLE
[youtube] make sure live chat playerOffsetMs is positive

### DIFF
--- a/youtube_dlc/downloader/youtube_live_chat.py
+++ b/youtube_dlc/downloader/youtube_live_chat.py
@@ -61,7 +61,7 @@ class YoutubeLiveChatReplayFD(FragmentFD):
             else:
                 url = ('https://www.youtube.com/live_chat_replay/get_live_chat_replay'
                        + '?continuation={}'.format(continuation_id)
-                       + '&playerOffsetMs={}'.format(offset - 5000)
+                       + '&playerOffsetMs={}'.format(max(offset - 5000, 0))
                        + '&hidden=false'
                        + '&pbj=1')
                 success, raw_fragment = dl_fragment(url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

If the `/live_chat_replay/get_live_chat_replay` endpoint is given a negative value to `playerOffsetMs`, it will return 400 bad request. It can happen when the first batch of messages is so large that all of them come before 5 seconds into the video. This pull request defaults the parameter to 0 when it's negative.

It's unclear if setting the parameter actually does anything when sequentially fetching all chat, but at least it looks more like what the browser does.